### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,4 +1,6 @@
 name: Django CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/avazcoderr/academy-back/security/code-scanning/1](https://github.com/avazcoderr/academy-back/security/code-scanning/1)

The best way to fix this problem is to explicitly add a `permissions` key specifying the minimal required permission for the workflow’s jobs. Since this workflow only checks out code, installs Python dependencies, and runs Django tests, it does not need to write to repository contents or interact with issues/PRs. The block should be added at the root of the workflow (line 2 or 3), applying to all jobs, and should set `contents: read`. No changes are needed to the workflow's steps. Only a single simple YAML block addition is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
